### PR TITLE
Feat/favorites filter studio search

### DIFF
--- a/src/main/java/com/slapp/service/dto/StudioFilterDTO.java
+++ b/src/main/java/com/slapp/service/dto/StudioFilterDTO.java
@@ -12,6 +12,7 @@ public class StudioFilterDTO {
     private BigDecimal maxPrice;
     private LocalDateTime availabilityStartDateTime;
     private LocalDateTime availabilityEndDateTime;
+    private Boolean onlyFavorites;
 
     // Construtor completo
     public StudioFilterDTO(
@@ -21,7 +22,8 @@ public class StudioFilterDTO {
         BigDecimal minPrice,
         BigDecimal maxPrice,
         LocalDateTime availabilityStartDateTime,
-        LocalDateTime availabilityEndDateTime
+        LocalDateTime availabilityEndDateTime,
+        Boolean onlyFavorites
     ) {
         this.name = name;
         this.city = city;
@@ -30,6 +32,7 @@ public class StudioFilterDTO {
         this.maxPrice = maxPrice;
         this.availabilityStartDateTime = availabilityStartDateTime;
         this.availabilityEndDateTime = availabilityEndDateTime;
+        this.onlyFavorites = onlyFavorites;
     }
 
     // Getters
@@ -61,6 +64,10 @@ public class StudioFilterDTO {
         return availabilityEndDateTime;
     }
 
+    public Boolean getOnlyFavorites() {
+        return onlyFavorites;
+    }
+
     // Setters
     public void setName(String name) {
         this.name = name;
@@ -90,6 +97,10 @@ public class StudioFilterDTO {
         this.availabilityEndDateTime = availabilityEndDateTime;
     }
 
+    public void setOnlyFavorites(Boolean onlyFavorites) {
+        this.onlyFavorites = onlyFavorites;
+    }
+
     // Métodos de validação
     public boolean hasNameFilter() {
         return name != null && !name.trim().isEmpty();
@@ -111,6 +122,10 @@ public class StudioFilterDTO {
         return availabilityStartDateTime != null && availabilityEndDateTime != null;
     }
 
+    public boolean hasOnlyFavoritesFilter() {
+        return onlyFavorites != null && onlyFavorites;
+    }
+
     // Builder pattern
     public static Builder builder() {
         return new Builder();
@@ -125,6 +140,7 @@ public class StudioFilterDTO {
         private BigDecimal maxPrice;
         private LocalDateTime availabilityStartDateTime;
         private LocalDateTime availabilityEndDateTime;
+        private Boolean onlyFavorites;
 
         public Builder name(String name) {
             this.name = name;
@@ -161,8 +177,22 @@ public class StudioFilterDTO {
             return this;
         }
 
+        public Builder onlyFavorites(Boolean onlyFavorites) {
+            this.onlyFavorites = onlyFavorites;
+            return this;
+        }
+
         public StudioFilterDTO build() {
-            return new StudioFilterDTO(name, city, roomType, minPrice, maxPrice, availabilityStartDateTime, availabilityEndDateTime);
+            return new StudioFilterDTO(
+                name,
+                city,
+                roomType,
+                minPrice,
+                maxPrice,
+                availabilityStartDateTime,
+                availabilityEndDateTime,
+                onlyFavorites
+            );
         }
     }
 }

--- a/src/main/java/com/slapp/service/impl/StudioServiceImpl.java
+++ b/src/main/java/com/slapp/service/impl/StudioServiceImpl.java
@@ -115,6 +115,7 @@ public class StudioServiceImpl implements StudioService {
             filters.getMaxPrice(),
             startInstant,
             endInstant,
+            filters.getOnlyFavorites(),
             pageable
         );
     }

--- a/src/main/java/com/slapp/web/rest/StudioResource.java
+++ b/src/main/java/com/slapp/web/rest/StudioResource.java
@@ -234,7 +234,8 @@ public class StudioResource {
         @RequestParam(required = false) BigDecimal minPrice,
         @RequestParam(required = false) BigDecimal maxPrice,
         @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime availabilityStartDateTime,
-        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime availabilityEndDateTime
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime availabilityEndDateTime,
+        @RequestParam(required = false) Boolean onlyFavorites
     ) {
         StudioFilterDTO filters = StudioFilterDTO.builder()
             .name(name)
@@ -244,6 +245,7 @@ public class StudioResource {
             .maxPrice(maxPrice)
             .availabilityStartDateTime(availabilityStartDateTime)
             .availabilityEndDateTime(availabilityEndDateTime)
+            .onlyFavorites(onlyFavorites)
             .build();
 
         final var page = studioService.getStudioRoomPagination(pageable, filters);

--- a/src/main/webapp/app/entities/studio/studio-search.tsx
+++ b/src/main/webapp/app/entities/studio/studio-search.tsx
@@ -22,6 +22,7 @@ interface ISearchFilters {
   maxPrice?: number;
   availabilityStartDateTime?: string; // novo
   availabilityEndDateTime?: string; // novo
+  onlyFavorites?: boolean; // filtro para mostrar apenas favoritos
 }
 
 interface StudioSearchProps {
@@ -45,6 +46,7 @@ const StudioSearch = (props: StudioSearchProps) => {
     sort: 'name,asc',
     availabilityStartDateTime: '',
     availabilityEndDateTime: '',
+    onlyFavorites: false,
   });
   const [showExtraFilters, setShowExtraFilters] = useState(false);
 
@@ -59,7 +61,8 @@ const StudioSearch = (props: StudioSearchProps) => {
       pesquisa.size === 6 &&
       pesquisa.sort === 'name,asc' &&
       pesquisa.availabilityStartDateTime === '' &&
-      pesquisa.availabilityEndDateTime === ''
+      pesquisa.availabilityEndDateTime === '' &&
+      pesquisa.onlyFavorites === false
     ) {
       setFilters({ ...pesquisa });
     }
@@ -85,11 +88,22 @@ const StudioSearch = (props: StudioSearchProps) => {
       sort: 'name,asc',
       availabilityStartDateTime: '',
       availabilityEndDateTime: '',
+      onlyFavorites: false,
     });
   };
 
   const addFiltros = () => {
     setShowExtraFilters(!showExtraFilters);
+  };
+
+  const handleFavoritesFilter = (e: React.FormEvent) => {
+    e.preventDefault();
+    const newFilters = { ...pesquisa, onlyFavorites: true };
+    setPesquisa(newFilters);
+    setFilters(prev => ({
+      ...prev,
+      ...newFilters,
+    }));
   };
 
   // 🔹 Handlers para juntar data e hora em availabilityStartDateTime e availabilityEndDateTime
@@ -182,9 +196,9 @@ const StudioSearch = (props: StudioSearchProps) => {
             <Col md={2} style={{ marginTop: '2rem' }}>
               <Button
                 variant="contained"
-                type="submit"
+                onClick={handleFavoritesFilter}
                 startIcon={<FavoriteIcon />}
-                className="button-slapp search-button"
+                className={`button-slapp search-button ${pesquisa.onlyFavorites ? 'active' : ''}`}
                 style={{ width: '100%' }}
               >
                 Favoritos

--- a/src/main/webapp/app/entities/studio/studio.reducer.ts
+++ b/src/main/webapp/app/entities/studio/studio.reducer.ts
@@ -120,6 +120,11 @@ export const getStudioPagination = createAsyncThunk(
       params.append('availabilityEndDateTime', endDateTime.endsWith('Z') ? endDateTime : `${endDateTime}.000Z`);
     }
 
+    // Filtro de favoritos
+    if (filters.onlyFavorites === true) {
+      params.append('onlyFavorites', 'true');
+    }
+
     params.append('cacheBuster', new Date().getTime().toString());
 
     const requestUrl = `${apiUrl}/pagination?${params.toString()}`;
@@ -156,6 +161,11 @@ export const loadMoreStudios = createAsyncThunk(
     if (filters.availabilityEndDateTime?.trim()) {
       const endDateTime = filters.availabilityEndDateTime.trim();
       params.append('availabilityEndDateTime', endDateTime.endsWith('Z') ? endDateTime : `${endDateTime}.000Z`);
+    }
+
+    // Filtro de favoritos
+    if (filters.onlyFavorites === true) {
+      params.append('onlyFavorites', 'true');
     }
 
     params.append('cacheBuster', new Date().getTime().toString());
@@ -199,6 +209,11 @@ export const loadMoreStudiosKeyset = createAsyncThunk(
     if (filters.availabilityEndDateTime?.trim()) {
       const endDateTime = filters.availabilityEndDateTime.trim();
       params.append('availabilityEndDateTime', endDateTime.endsWith('Z') ? endDateTime : `${endDateTime}.000Z`);
+    }
+
+    // Filtro de favoritos
+    if (filters.onlyFavorites === true) {
+      params.append('onlyFavorites', 'true');
     }
 
     params.append('cacheBuster', new Date().getTime().toString());

--- a/src/main/webapp/app/shared/reducers/reducer.utils.ts
+++ b/src/main/webapp/app/shared/reducers/reducer.utils.ts
@@ -21,6 +21,7 @@ export interface IStudioFilters {
   maxPrice?: number;
   availabilityStartDateTime?: string; // novo
   availabilityEndDateTime?: string; // novo
+  onlyFavorites?: boolean; // filtro para mostrar apenas favoritos
 }
 
 /**


### PR DESCRIPTION
Adiciona filtro de favoritos no StudioSearch
Implementa funcionalidade para filtrar apenas studios marcados como favoritos pelo usuário autenticado. 
Integra botão existente com Redux actions e state management.
Adiciona parâmetro onlyFavorites no StudioFilterDTO e queries SQL otimizadas para buscar apenas studios favoritos do usuário autenticado via Spring Security.